### PR TITLE
DP-57-JoinSessionFlow-Fix

### DIFF
--- a/DavaiPosmotrim/Application/AppCoordinator.swift
+++ b/DavaiPosmotrim/Application/AppCoordinator.swift
@@ -48,18 +48,6 @@ private extension AppCoordinator {
         onboardingCoordinator.start()
     }
 
-    //TODO: - Переделать и убрать отсюда после удаления обсерверов в ветке JoinSessionFlow, вынести логику отображения туда
-
-    func showMovieSelectionOnboardingFlow() {
-        let onboardingCoordinator = MovieSelectionOnboardingCoordinator(
-            type: .movieSelectionOnboarding,
-            finishDelegate: self,
-            navigationController: navigationController
-        )
-        addChild(onboardingCoordinator)
-        onboardingCoordinator.start()
-    }
-
     func showAuthFlow() {
         let authCoordinator = AuthCoordinator(
             type: .auth,
@@ -78,18 +66,6 @@ private extension AppCoordinator {
         addChild(mainCoordinator)
         mainCoordinator.start()
     }
-
-//TODO: - Переделать и убрать отсюда после удаления обсерверов в ветке JoinSessionFlow
-
-    func showJoinSessionFlow() {
-        let joinSessionCoordinator = JoinSessionCoordinator(
-            type: .joinSession,
-            finishDelegate: self,
-            navigationController: navigationController
-        )
-        addChild(joinSessionCoordinator)
-        joinSessionCoordinator.start()
-    }
 }
 
 extension AppCoordinator: CoordinatorFinishDelegate {
@@ -102,14 +78,7 @@ extension AppCoordinator: CoordinatorFinishDelegate {
             return
         case .onboarding:
             showAuthFlow()
-        case .movieSelectionOnboarding:
-            // TODO: add code to start next flow
-            print("MovieSelectionOnboarding")
         case .auth:
-            showMainFlow()
-        case .main:
-            showJoinSessionFlow()
-        case .joinSession:
             showMainFlow()
         default:
             navigationController.popToRootViewController(animated: false)

--- a/DavaiPosmotrim/AuthFlow/AuthPresenter.swift
+++ b/DavaiPosmotrim/AuthFlow/AuthPresenter.swift
@@ -87,13 +87,6 @@ final class AuthPresenter: AuthPresenterProtocol {
         }
     }
 
-    func startJoinSessionFlowNotification() {
-        NotificationCenter.default.post(
-            name: NSNotification.Name(Resources.MainScreen.startJoinSessionFlow),
-            object: nil
-        )
-    }
-
     func handleEnterButtonTap(with name: String) -> String {
         if name.isEmpty {
             view?.updateUIElements(

--- a/DavaiPosmotrim/AuthFlow/AuthPresenterProtocol.swift
+++ b/DavaiPosmotrim/AuthFlow/AuthPresenterProtocol.swift
@@ -11,7 +11,6 @@ protocol AuthPresenterProtocol: AnyObject {
     func authFinish()
     func calculateCharactersNumber(with text: String)
     func checkSessionCode(with code: String)
-    func startJoinSessionFlowNotification()
     func handleEnterButtonTap(with name: String) -> String
     func checkUserNameProperty() -> String
     func authDidFinishNotification(userName: String)

--- a/DavaiPosmotrim/AuthFlow/AuthViewController.swift
+++ b/DavaiPosmotrim/AuthFlow/AuthViewController.swift
@@ -182,8 +182,6 @@ final class AuthViewController: UIViewController {
         if authEvent != .joinSession {
             userName = presenter.handleEnterButtonTap(with: text)
             presenter.authDidFinishNotification(userName: userName)
-        } else {
-            presenter.startJoinSessionFlowNotification()
         }
 
         nameTextField.resignFirstResponder()

--- a/DavaiPosmotrim/InvitingUsersFlow/InvitingUsersPresenter.swift
+++ b/DavaiPosmotrim/InvitingUsersFlow/InvitingUsersPresenter.swift
@@ -88,7 +88,6 @@ final class InvitingUsersPresenter: InvitingUsersPresenterProtocol {
                 ReusableCollectionCellModel(title: "Максим")
             ]
 
-            var index = 0
             let delayInSeconds: TimeInterval = 2
 
             downloadedNames.enumerated().forEach() { index, name in

--- a/DavaiPosmotrim/JoinSessionFlow/JoinSessionCoordinator.swift
+++ b/DavaiPosmotrim/JoinSessionFlow/JoinSessionCoordinator.swift
@@ -16,11 +16,51 @@ final class JoinSessionCoordinator: BaseCoordinator {
     override func finish() {
         finishDelegate?.didFinish(self)
     }
+
+    func showStartSessionScreen() {
+        if UserDefaults.standard.value(forKey: Resources.MovieSelectionOnboarding.movieSelectionOnboardingUserDefaultsKey) == nil {
+            showMovieSelectionOnboardingScreen()
+        } else {
+            showSelectionMovieScreen()
+        }
+    }
 }
 
 private extension JoinSessionCoordinator {
     func showJoinSession() {
         let viewController = JoinSessionSceneFactory.makeJoinSessionViewController(with: self)
-        navigationController.setViewControllers([viewController], animated: true)
+        navigationController.pushViewController(viewController, animated: true)
+    }
+
+    func showSelectionMovieScreen() {
+        let selectionMovieCoordinator = SelectionMoviesCoordinator(
+            type: .selectionMovies,
+            finishDelegate: finishDelegate,
+            navigationController: navigationController)
+        addChild(selectionMovieCoordinator)
+        selectionMovieCoordinator.start()
+    }
+
+    func showMovieSelectionOnboardingScreen() {
+        let movieSelectionOnboardingCoordinator = MovieSelectionOnboardingCoordinator(
+            type: .movieSelectionOnboarding,
+            finishDelegate: self,
+            navigationController: navigationController)
+        addChild(movieSelectionOnboardingCoordinator)
+        movieSelectionOnboardingCoordinator.start()
+    }
+}
+
+// MARK: - CoordinatorFinishDelegate
+
+extension JoinSessionCoordinator: CoordinatorFinishDelegate {
+    func didFinish(_ coordinator: any CoordinatorProtocol) {
+        switch coordinator.type {
+        case .movieSelectionOnboarding:
+            showSelectionMovieScreen()
+            removeChild(coordinator)
+        default:
+            return
+        }
     }
 }

--- a/DavaiPosmotrim/JoinSessionFlow/JoinSessionPresenter.swift
+++ b/DavaiPosmotrim/JoinSessionFlow/JoinSessionPresenter.swift
@@ -52,14 +52,19 @@ final class JoinSessionPresenter: JoinSessionPresenterProtocol {
                 ReusableCollectionCellModel(title: "Максим")
             ]
 
-            var index = 0
             let delayInSeconds: TimeInterval = 2
+            let dispatchGroup = DispatchGroup()
 
-            for name in downloadedNames {
+            downloadedNames.enumerated().forEach { index, name in
+                dispatchGroup.enter()
                 DispatchQueue.global().asyncAfter(deadline: .now() + delayInSeconds * Double(index)) {
                     self.namesArray.append(name)
+                    dispatchGroup.leave()
                 }
-                index += 1
+            }
+
+            dispatchGroup.notify(queue: .main) {
+                self.coordinator?.showStartSessionScreen()
             }
         }
     }

--- a/DavaiPosmotrim/MainFlow/MainCoordinator.swift
+++ b/DavaiPosmotrim/MainFlow/MainCoordinator.swift
@@ -33,7 +33,7 @@ final class MainCoordinator: BaseCoordinator {
         case Keys.favoriteMoviesViewController:
                 showSessionsList()
         case Keys.joinSessionViewController:
-            showJoinSessionFlow()
+            showJoinSessionAuth()
         default:
             break
         }
@@ -65,7 +65,7 @@ private extension MainCoordinator {
         createSessionCoordinator.start()
     }
 
-    func showJoinSessionFlow() {
+    func showJoinSessionAuth() {
         let authSessionCoordinator = AuthCoordinator(
             type: .authSession,
             finishDelegate: self,
@@ -73,6 +73,16 @@ private extension MainCoordinator {
         )
         addChild(authSessionCoordinator)
         authSessionCoordinator.start()
+    }
+
+    func showJoinSessionFlow() {
+        let joinSessionCoordinator = JoinSessionCoordinator(
+            type: .joinSession,
+            finishDelegate: self,
+            navigationController: navigationController
+        )
+        addChild(joinSessionCoordinator)
+        joinSessionCoordinator.start()
     }
 
     func showSessionsList() {
@@ -93,7 +103,7 @@ extension MainCoordinator: CoordinatorFinishDelegate {
         childCoordinators.removeAll()
         switch coordinator.type {
         case .authSession:
-            return
+            showJoinSessionFlow()
         case .selectionMovies:
             showSessionsList()
         default:

--- a/DavaiPosmotrim/MainFlow/MainPresenter.swift
+++ b/DavaiPosmotrim/MainFlow/MainPresenter.swift
@@ -22,11 +22,6 @@ final class MainPresenter: MainPresenterProtocol {
         coordinator.showNextScreen(screen: screen)
     }
 
-    func finishCoordinator() {
-        guard let coordinator else { return }
-        coordinator.finish()
-    }
-
     func checkUserNameProperty() -> String {
         guard let savedName = UserDefaults.standard.string(
             forKey: Resources.Authentication.savedNameUserDefaultsKey

--- a/DavaiPosmotrim/MainFlow/MainPresenterProtocol.swift
+++ b/DavaiPosmotrim/MainFlow/MainPresenterProtocol.swift
@@ -8,7 +8,6 @@
 import Foundation
 
 protocol MainPresenterProtocol: AnyObject {
-    func finishCoordinator()
     func didTapButtons(screen: String)
     func checkUserNameProperty() -> String
     func getUserName(_ notification: Notification) -> String

--- a/DavaiPosmotrim/MainFlow/MainViewController.swift
+++ b/DavaiPosmotrim/MainFlow/MainViewController.swift
@@ -141,7 +141,6 @@ final class MainViewController: UIViewController {
         setupSubviews()
         setupConstraints()
         setupAuthNotificationObserver()
-        setupJoinNotificationObserver()
         setupTableViewHeightConstraint()
     }
 
@@ -160,11 +159,6 @@ final class MainViewController: UIViewController {
         nameLabel.text = presenter?.getUserName(notification)
     }
 
-    @objc private func finishMainFlow() {
-        guard let presenter else { return }
-        presenter.finishCoordinator()
-    }
-
     // MARK: - Private methods
 
     private func setupAuthNotificationObserver() {
@@ -172,15 +166,6 @@ final class MainViewController: UIViewController {
             self,
             selector: #selector(updateUserName(_:)),
             name: Notification.Name(Resources.Authentication.authDidFinishNotification),
-            object: nil
-        )
-    }
-
-    private func setupJoinNotificationObserver() {
-        NotificationCenter.default.addObserver(
-            self,
-            selector: #selector(finishMainFlow),
-            name: NSNotification.Name(Resources.MainScreen.startJoinSessionFlow),
             object: nil
         )
     }


### PR DESCRIPTION
Саша, посмотри мои изменения по исправлению JoinSessionFlow.
Проверил у себя всё несколько раз, но лучше чтобы ты еще глянул. Вдруг что-то забыл исправить или наоборот.

Сейчас JoinSessionFlow запускается после финиша экрана авторизации сессии (модального) и финишируется, когда запускается новое флоу с онбордингом или выбором фильмов.
ФинишДелегатом экрана присоединения к сессии является MainCoordinator.

Close #57 